### PR TITLE
Agregando esperas implicitas a los archivos de configuracion

### DIFF
--- a/protractor/headless.config.ts
+++ b/protractor/headless.config.ts
@@ -7,6 +7,7 @@ export const config: Config = {
   onPrepare: () => {
     browser.ignoreSynchronization = true;
     reporter();
+    browser.manage().timeouts().implicitlyWait(3000);
   },
   capabilities: {
     browserName: 'chrome',
@@ -16,6 +17,6 @@ export const config: Config = {
   },
   getPageTimeout: 3000,
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 120000
+    defaultTimeoutInterval: 12000
   }
 };

--- a/protractor/local.config.ts
+++ b/protractor/local.config.ts
@@ -7,9 +7,10 @@ export const config: Config = {
   onPrepare: () => {
     browser.ignoreSynchronization = true;
     reporter();
+    browser.manage().timeouts().implicitlyWait(3000);
   },
   getPageTimeout: 3000,
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 12000
+    defaultTimeoutInterval: 25000
   }
 };

--- a/test/buy-tshirt.spec.ts
+++ b/test/buy-tshirt.spec.ts
@@ -18,31 +18,28 @@ describe('Buy a t-shirt', () => {
 
   it('then should be bought a t-shirt', async () => {
     await browser.get('http://automationpractice.com/');
+
     await menuContentPage.goToTShirtMenu();
-    await(browser.sleep(3000));
+
     await productListPage.goToProductAddeModal();
-    await(browser.sleep(3000));
+
     await productAddedModalPage.goToSummaryPage();
-    await(browser.sleep(3000));
+
     await sumaryStepPage.goToSignIn();
-    await(browser.sleep(3000));
+
     await singInPage.writeEmail();
     await singInPage.writePassword();
     await singInPage.submit();
-    await(browser.sleep(3000));
 
     await addressStepPage.goToShippingPage();
-    await(browser.sleep(3000));
 
     await shippingStepPage.clickAcceptTerms();
-    await(browser.sleep(3000));
 
     await shippingStepPage.goToPaymentPage();
-    await(browser.sleep(3000));
+
     await paymentStepPage.goToBankPaymentPage();
-    await(browser.sleep(3000));
+
     await bankPaymentPage.comfirmOrder();
-    await(browser.sleep(3000));
 
     await expect(orderSumaryPage.getResultOrder())
       .toBe('Your order on My Store is complete.');

--- a/test/google.spec.ts
+++ b/test/google.spec.ts
@@ -2,10 +2,8 @@ import { browser } from 'protractor';
 
 describe('Given a SDET learning protracor', () => {
   describe('When open Google page', () => {
-    beforeEach(async () => {
-      await browser.get('http://www.google.com');
-    });
     it('then should have a title', async () => {
+      await browser.get('http://www.google.com');
       await expect(browser.getTitle()).toEqual('Google');
     });
   });

--- a/test/google.spec.ts
+++ b/test/google.spec.ts
@@ -2,8 +2,10 @@ import { browser } from 'protractor';
 
 describe('Given a SDET learning protracor', () => {
   describe('When open Google page', () => {
-    it('then should have a title', async () => {
+    beforeEach(async () => {
       await browser.get('http://www.google.com');
+    });
+    it('then should have a title', async () => {
       await expect(browser.getTitle()).toEqual('Google');
     });
   });


### PR DESCRIPTION
Completando parte 13 del workshop, eliminando los sleep y añadiendo browser.manage().timeouts().implicitlyWait(); en los archivos de configuracion de las pruebas headless y gráficas.